### PR TITLE
Add accounting major

### DIFF
--- a/degree_data/accounting.json
+++ b/degree_data/accounting.json
@@ -48,10 +48,21 @@
           {
             "matcher": "CourseRequirement",
             "course": "OPRE 3333"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "MATH 2333"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "MATH 2418"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "CS 2305"
           }
         ]
       },
-
       {
         "matcher": "OrRequirement",
         "requirements": [

--- a/degree_data/accounting.json
+++ b/degree_data/accounting.json
@@ -1,0 +1,292 @@
+{
+  "abbreviation": "Accounting (BS)",
+  "catalog_uri": "https://catalog.utdallas.edu/2022/undergraduate/programs/jsom/accounting",
+  "minimum_credit_hours": 120,
+  "name": "Bachelor of Science in Accounting",
+  "school": "Naveen Jindal School of Management",
+  "subtype": "Major",
+  "year": "2022-2023",
+  "requirements": [
+    [
+      {
+        "matcher": "CourseRequirement",
+        "course": "MATH 1325"
+      },
+      {
+        "matcher": "OrRequirement",
+        "requirements": [
+          {
+            "matcher": "CourseRequirement",
+            "course": "MATH 1326"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "PHIL 2303"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "OPRE 3340"
+          }
+        ]
+      },
+      {
+        "matcher": "CourseRequirement",
+        "course": "ACCT 2301"
+      },
+      {
+        "matcher": "CourseRequirement",
+        "course": "ACCT 2302"
+      },
+      {
+        "matcher": "CourseRequirement",
+        "course": "BLAW 2301"
+      },
+      {
+        "matcher": "OrRequirement",
+        "requirements": [
+          {
+            "matcher": "CourseRequirement",
+            "course": "OPRE 3333"
+          }
+        ]
+      },
+
+      {
+        "matcher": "OrRequirement",
+        "requirements": [
+          {
+            "matcher": "CourseRequirement",
+            "course": "OPRE 3360"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "STAT 3360"
+          }
+        ]
+      },
+
+      {
+        "matcher": "SelectRequirement",
+        "required_course_count": 2,
+        "requirements": [
+          {
+            "matcher": "CourseRequirement",
+            "course": "BA 1310"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "BA 1320"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "ECON 2301"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "ECON 2302"
+          }
+        ]
+      },
+      {
+        "matcher": "OrRequirement",
+        "requirements": [
+          {
+            "matcher": "CourseRequirement",
+            "course": "BCOM 1300"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "BCOM 3300"
+          }
+        ]
+      },
+
+      {
+        "matcher": "CourseRequirement",
+        "course": "BCOM 4300"
+      },
+      {
+        "matcher": "CourseRequirement",
+        "course": "IMS 3310"
+      },
+      {
+        "matcher": "CourseRequirement",
+        "course": "FIN 3320"
+      },
+      {
+        "matcher": "CourseRequirement",
+        "course": "ITSS 3300"
+      },
+      {
+        "matcher": "CourseRequirement",
+        "course": "OPRE 3310"
+      },
+
+      {
+        "matcher": "OrRequirement",
+        "requirements": [
+          {
+            "matcher": "CourseRequirement",
+            "course": "OBHR 3330"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "OBHR 3310"
+          }
+        ]
+      },
+
+      {
+        "matcher": "CourseRequirement",
+        "course": "MKT 3300"
+      },
+      {
+        "matcher": "OrRequirement",
+        "requirements": [
+          {
+            "matcher": "CourseRequirement",
+            "course": "ACCT 4395"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "BPS 4395"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "ENTP 4395"
+          }
+        ]
+      },
+
+      {
+        "matcher": "CourseRequirement",
+        "course": "ACCT 3312"
+      },
+      {
+        "matcher": "CourseRequirement",
+        "course": "ACCT 3331"
+      },
+      {
+        "matcher": "CourseRequirement",
+        "course": "ACCT 3332"
+      },
+      {
+        "matcher": "CourseRequirement",
+        "course": "ACCT 3341"
+      },
+      {
+        "matcher": "CourseRequirement",
+        "course": "ACCT 3350"
+      },
+      {
+        "matcher": "CourseRequirement",
+        "course": "ACCT 4334"
+      },
+      {
+        "matcher": "CourseRequirement",
+        "course": "ACCT 4342"
+      },
+      {
+        "matcher": "OrRequirement",
+        "requirements": [
+          {
+            "matcher": "CourseRequirement",
+            "course": "ACCT 4V80"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "BA 4090"
+          }
+        ]
+      },
+      {
+        "matcher": "HoursRequirement",
+        "required_hours": 12,
+        "requirements": [
+          {
+            "matcher": "CourseRequirement",
+            "course": "ACCT 4V80"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "BA 4090"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "ACCT 3322"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "ACCT 4301"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "ACCT 4302"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "ACCT 4336"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "ACCT 4337"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "ACCT 4340"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "FIN 3330"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "FIN 3360"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "FIN 3380"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "FIN 3390"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "ITSS 4340"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "OPRE 4350"
+          }
+        ]
+      },
+      {
+        "matcher": "OrRequirement",
+        "requirements": [
+          {
+            "matcher": "CourseRequirement",
+            "course": "IMS 4335"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "ENTP 4340"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "MKT 4360"
+          },
+          {
+            "matcher": "CourseRequirement",
+            "course": "BA 4095"
+          }
+        ]
+      },
+      {
+        "matcher": "FreeElectiveRequirement",
+        "required_hours": 0,
+        "excluded_courses": []
+      }
+    ]
+  ]
+}

--- a/degree_data/accounting.json
+++ b/degree_data/accounting.json
@@ -6,8 +6,9 @@
   "school": "Naveen Jindal School of Management",
   "subtype": "Major",
   "year": "2022-2023",
-  "requirements": [
-    [
+  "requirements": {
+    "core": "@import ./core.json",
+    "major": [
       {
         "matcher": "CourseRequirement",
         "course": "MATH 1325"
@@ -288,5 +289,5 @@
         "excluded_courses": []
       }
     ]
-  ]
+  }
 }

--- a/major/requirements/map.py
+++ b/major/requirements/map.py
@@ -10,6 +10,7 @@ REQUIREMENTS_MAP: dict[str, Type[AbstractRequirement]] = {
     "OrRequirement": OrRequirement,
     "FreeElectiveRequirement": FreeElectiveRequirement,
     "SelectRequirement": SelectRequirement,
+    "HoursRequirement": HoursRequirement,
     # Computer Science Edge Cases
     "CS_MajorGuidedElectiveRequirement": computer_science.MajorGuidedElectiveRequirement,
 }

--- a/major/requirements/map.py
+++ b/major/requirements/map.py
@@ -9,6 +9,7 @@ REQUIREMENTS_MAP: dict[str, Type[AbstractRequirement]] = {
     "AndRequirement": AndRequirement,
     "OrRequirement": OrRequirement,
     "FreeElectiveRequirement": FreeElectiveRequirement,
+    "SelectRequirement": SelectRequirement,
     # Computer Science Edge Cases
     "CS_MajorGuidedElectiveRequirement": computer_science.MajorGuidedElectiveRequirement,
 }

--- a/major/requirements/shared.py
+++ b/major/requirements/shared.py
@@ -54,8 +54,8 @@ class AndRequirement(AbstractRequirement):
             return False
 
         filled_one = False
-        for requirements in self.requirements:
-            filled_one = filled_one or requirements.attempt_fulfill(course)
+        for requirement in self.requirements:
+            filled_one = filled_one or requirement.attempt_fulfill(course)
 
         return filled_one
 
@@ -98,8 +98,8 @@ class OrRequirement(AbstractRequirement):
             return False
 
         filled_one = False
-        for requirements in self.requirements:
-            filled_one = filled_one or requirements.attempt_fulfill(course)
+        for requirement in self.requirements:
+            filled_one = filled_one or requirement.attempt_fulfill(course)
 
         return filled_one
 
@@ -185,3 +185,4 @@ class FreeElectiveRequirement(AbstractRequirement):
         fulfilled_hours: {self.fulfilled_hours}
         """
         return s
+

--- a/major/requirements/shared.py
+++ b/major/requirements/shared.py
@@ -128,6 +128,65 @@ class OrRequirement(AbstractRequirement):
     def __str__(self) -> str:
         return f"({' or '.join([str(req) for req in self.requirements])}) -> {self.is_fulfilled()}"
 
+class HoursRequirement(AbstractRequirement):
+    """Any requirement with minimum # hours
+
+    Requires minimum of required_hours to be fulfilled
+
+    Parameters
+    __________
+    required_hours: int
+        Minimum # of hours before requirement is fulfilled
+
+    """
+
+    def __init__(self, required_hours: int, requirements: list[AbstractRequirement]) -> None:
+        self.required_hours = required_hours
+        self.fulfilled_hours = 0
+        self.requirements = set(requirements)
+
+    def attempt_fulfill(self, course: str) -> bool:
+        if self.is_fulfilled():
+            return False
+
+        filled_one = False
+        for requirement in self.requirements:
+            filled_one = filled_one or requirement.attempt_fulfill(course)
+
+        return filled_one
+
+    def is_fulfilled(self) -> bool:
+        return self.fulfilled_hours >= self.required_hours
+
+    class JSON(TypedDict):
+        required_hours: int
+        requirements: list[AbstractRequirement]
+
+    @classmethod
+    def from_json(cls, json: JSON) -> AbstractRequirement:
+        """
+        {
+            "required_hours": 10,
+            "requirements": [
+              {
+                        "matcher": "CourseRequirement",
+                        "course": "ACCT 4V80"
+                      },
+                      {
+                        "matcher": "CourseRequirement",
+                        "course": "BA 4090"
+                      } 
+            ]
+        """
+
+        return cls(json["required_hours"], json["requirements"])
+
+    def __str__(self) -> str:
+        s = f"""{FreeElectiveRequirement.__name__} 
+        required_hours: {self.required_hours}
+        fulfilled_hours: {self.fulfilled_hours}
+        """
+        return s
 
 class FreeElectiveRequirement(AbstractRequirement):
     """Defines Major Free Electives

--- a/major/requirements/shared.py
+++ b/major/requirements/shared.py
@@ -128,6 +128,7 @@ class OrRequirement(AbstractRequirement):
     def __str__(self) -> str:
         return f"({' or '.join([str(req) for req in self.requirements])}) -> {self.is_fulfilled()}"
 
+
 class HoursRequirement(AbstractRequirement):
     """Any requirement with minimum # hours
 
@@ -140,7 +141,9 @@ class HoursRequirement(AbstractRequirement):
 
     """
 
-    def __init__(self, required_hours: int, requirements: list[AbstractRequirement]) -> None:
+    def __init__(
+        self, required_hours: int, requirements: list[AbstractRequirement]
+    ) -> None:
         self.required_hours = required_hours
         self.fulfilled_hours = 0
         self.requirements = set(requirements)
@@ -149,7 +152,6 @@ class HoursRequirement(AbstractRequirement):
     def attempt_fulfill(self, course: str) -> bool:
         if self.is_fulfilled():
             return False
-
 
         for requirement in self.requirements:
             if requirement.attempt_fulfill(course):
@@ -166,7 +168,7 @@ class HoursRequirement(AbstractRequirement):
     class JSON(TypedDict):
         required_hours: int
         requirements: list[HoursRequirement.Req]
-    
+
     @classmethod
     def from_json(cls, json: JSON) -> AbstractRequirement:
         """
@@ -180,7 +182,7 @@ class HoursRequirement(AbstractRequirement):
                       {
                         "matcher": "CourseRequirement",
                         "course": "BA 4090"
-                      } 
+                      }
             ]
         """
 
@@ -193,7 +195,6 @@ class HoursRequirement(AbstractRequirement):
             )
             matchers.append(matcher)
 
-
         return cls(json["required_hours"], matchers)
 
     def __str__(self) -> str:
@@ -202,6 +203,7 @@ class HoursRequirement(AbstractRequirement):
         fulfilled_hours: {self.fulfilled_hours}
         """
         return s
+
 
 class FreeElectiveRequirement(AbstractRequirement):
     """Defines Major Free Electives
@@ -260,6 +262,7 @@ class FreeElectiveRequirement(AbstractRequirement):
         """
         return s
 
+
 class SelectRequirement(AbstractRequirement):
     """Matches x requirements out of a list to be fulfilled
 
@@ -271,7 +274,9 @@ class SelectRequirement(AbstractRequirement):
         Minimum # of fulfillments before requirement is fulfilled
     """
 
-    def __init__(self, required_count: int, requirements: list[AbstractRequirement]) -> None:
+    def __init__(
+        self, required_count: int, requirements: list[AbstractRequirement]
+    ) -> None:
         self.required_count = required_count
         self.fulfilled_count = 0
         self.requirements = set(requirements)
@@ -281,7 +286,7 @@ class SelectRequirement(AbstractRequirement):
             return False
 
         for requirements in self.requirements:
-            if (requirements.attempt_fulfill(course)):
+            if requirements.attempt_fulfill(course):
                 self.fulfilled_count += 1
                 return True
 
@@ -289,10 +294,10 @@ class SelectRequirement(AbstractRequirement):
 
     def is_fulfilled(self) -> bool:
         curr = 0
-        
+
         for requirement in self.requirements:
             if requirement.is_fulfilled():
-                curr +=  1
+                curr += 1
         return curr >= self.required_count
 
     class Req(TypedDict):
@@ -317,5 +322,3 @@ class SelectRequirement(AbstractRequirement):
 
     def __str__(self) -> str:
         return f"({' or '.join([str(req) for req in self.requirements])}) -> {self.is_fulfilled()}"
-       
-        

--- a/major/tests/edge_cases/test_computer_science.py
+++ b/major/tests/edge_cases/test_computer_science.py
@@ -5,7 +5,7 @@ from major.requirements import CourseRequirement
 import json
 
 
-def test_or_requirement() -> None:
+def test_major_guided_elective_requirement() -> None:
     req = MajorGuidedElectiveRequirement(
         3,
         "CS 43",

--- a/major/tests/test_degrees.py
+++ b/major/tests/test_degrees.py
@@ -12,6 +12,7 @@ def test_computer_science() -> None:
     for requirement in requirements:
         REQUIREMENTS_MAP[requirement["matcher"]].from_json(requirement)
 
+
 def test_accounting() -> None:
     data = json.loads(open("./degree_data/accounting.json", "r").read())
 

--- a/major/tests/test_degrees.py
+++ b/major/tests/test_degrees.py
@@ -3,8 +3,17 @@ import json
 
 
 # just make sure none of the matchers throw an error
-def test_computer_science():
+def test_computer_science() -> None:
     data = json.loads(open("./degree_data/computer_science.json", "r").read())
+
+    requirements = data["requirements"]["major"]
+
+    # make sure all requirements are parseable
+    for requirement in requirements:
+        REQUIREMENTS_MAP[requirement["matcher"]].from_json(requirement)
+
+def test_accounting() -> None:
+    data = json.loads(open("./degree_data/accounting.json", "r").read())
 
     requirements = data["requirements"]["major"]
 

--- a/major/tests/test_shared_requirements.py
+++ b/major/tests/test_shared_requirements.py
@@ -2,12 +2,14 @@ from requirements import (
     CourseRequirement,
     AndRequirement,
     OrRequirement,
+    HoursRequirement,
     FreeElectiveRequirement,
+    SelectRequirement
 )
 import json
 
 
-def test_course_requirement():
+def test_course_requirement() -> None:
     course_req = CourseRequirement("HIST 1301")
     course_req.attempt_fulfill("HIST 1301")
 
@@ -26,7 +28,7 @@ def test_course_requirement():
     assert course_req.course == "HIST 1301"
 
 
-def test_and_requirement():
+def test_and_requirement() -> None:
     and_req = AndRequirement(
         [
             CourseRequirement("HIST 1301"),
@@ -62,7 +64,7 @@ def test_and_requirement():
     assert and_req.is_fulfilled()
 
 
-def test_or_requirement():
+def test_or_requirement() -> None:
     or_req = OrRequirement(
         [
             CourseRequirement("HIST 1301"),
@@ -95,8 +97,46 @@ def test_or_requirement():
     assert or_req.attempt_fulfill("HIST 1301")
     assert or_req.is_fulfilled()
 
+def test_hours_requirement() -> None:
+    hours_req = HoursRequirement(12, [CourseRequirement("ACCT 3322"),
+		CourseRequirement("ACCT 4301"),
+		CourseRequirement("ACCT 4302"),
+		CourseRequirement("ACCT 4336"),
+		CourseRequirement("ACCT 4337"),
+		CourseRequirement("ACCT 4340"),
+		CourseRequirement("FIN 3330"),
+		CourseRequirement("FIN 3360"),
+		CourseRequirement("FIN 3380"),
+		CourseRequirement("FIN 3390"),
+		CourseRequirement("ITSS 4340"),
+		CourseRequirement("OPRE 4350")])
+    
+    assert hours_req.fulfilled_hours == 0
+    assert hours_req.is_fulfilled() == False
+    
+    hours_req.attempt_fulfill("ACCT 3322")
+    hours_req.attempt_fulfill("FFFF 1111")
 
-def test_free_elective_requirement():
+    assert hours_req.fulfilled_hours == 3
+    assert hours_req.is_fulfilled() == False
+
+    hours_req.attempt_fulfill("ACCT 3322")
+    assert hours_req.fulfilled_hours == 3
+    assert hours_req.is_fulfilled() == False
+
+
+    hours_req.attempt_fulfill("ACCT 4301")
+    hours_req.attempt_fulfill("FIN 3380")
+    hours_req.attempt_fulfill("FIN 3390")
+
+    assert hours_req.fulfilled_hours == 12
+    assert hours_req.is_fulfilled() == True
+
+    hours_req.attempt_fulfill("FIN 3330")
+    assert hours_req.fulfilled_hours == 12
+    assert hours_req.is_fulfilled() == True
+
+def test_free_elective_requirement() -> None:
     free_elective_req = FreeElectiveRequirement(10, ["HIST 1301", "HIST 1302"])
     free_elective_req.attempt_fulfill("HIST 1301")
     free_elective_req.attempt_fulfill("HIST 1302")
@@ -124,3 +164,24 @@ def test_free_elective_requirement():
     free_elective_req.attempt_fulfill("HIST 1301")
 
     assert free_elective_req.fulfilled_hours == 0
+
+def test_select_requirement() -> None:
+    select_req = SelectRequirement(2, [CourseRequirement("BA 1310"), CourseRequirement("BA 1320"), CourseRequirement("ECON 2301"), CourseRequirement("ECON 2302")])
+    assert select_req.fulfilled_count == 0
+    assert select_req.is_fulfilled() == False
+
+    select_req.attempt_fulfill("GANG 1000")
+    assert select_req.fulfilled_count == 0
+    assert select_req.is_fulfilled() == False
+
+    select_req.attempt_fulfill("BA 1320") 
+    assert select_req.fulfilled_count == 1
+    assert select_req.is_fulfilled() == False
+
+    select_req.attempt_fulfill("BA 1310") 
+    assert select_req.fulfilled_count == 2
+    assert select_req.is_fulfilled() == True
+
+    select_req.attempt_fulfill("ECON 2301") 
+    assert select_req.fulfilled_count == 2
+    assert select_req.is_fulfilled() == True

--- a/major/tests/test_shared_requirements.py
+++ b/major/tests/test_shared_requirements.py
@@ -4,7 +4,7 @@ from requirements import (
     OrRequirement,
     HoursRequirement,
     FreeElectiveRequirement,
-    SelectRequirement
+    SelectRequirement,
 )
 import json
 
@@ -97,23 +97,29 @@ def test_or_requirement() -> None:
     assert or_req.attempt_fulfill("HIST 1301")
     assert or_req.is_fulfilled()
 
+
 def test_hours_requirement() -> None:
-    hours_req = HoursRequirement(12, [CourseRequirement("ACCT 3322"),
-		CourseRequirement("ACCT 4301"),
-		CourseRequirement("ACCT 4302"),
-		CourseRequirement("ACCT 4336"),
-		CourseRequirement("ACCT 4337"),
-		CourseRequirement("ACCT 4340"),
-		CourseRequirement("FIN 3330"),
-		CourseRequirement("FIN 3360"),
-		CourseRequirement("FIN 3380"),
-		CourseRequirement("FIN 3390"),
-		CourseRequirement("ITSS 4340"),
-		CourseRequirement("OPRE 4350")])
-    
+    hours_req = HoursRequirement(
+        12,
+        [
+            CourseRequirement("ACCT 3322"),
+            CourseRequirement("ACCT 4301"),
+            CourseRequirement("ACCT 4302"),
+            CourseRequirement("ACCT 4336"),
+            CourseRequirement("ACCT 4337"),
+            CourseRequirement("ACCT 4340"),
+            CourseRequirement("FIN 3330"),
+            CourseRequirement("FIN 3360"),
+            CourseRequirement("FIN 3380"),
+            CourseRequirement("FIN 3390"),
+            CourseRequirement("ITSS 4340"),
+            CourseRequirement("OPRE 4350"),
+        ],
+    )
+
     assert hours_req.fulfilled_hours == 0
     assert hours_req.is_fulfilled() == False
-    
+
     hours_req.attempt_fulfill("ACCT 3322")
     hours_req.attempt_fulfill("FFFF 1111")
 
@@ -123,7 +129,6 @@ def test_hours_requirement() -> None:
     hours_req.attempt_fulfill("ACCT 3322")
     assert hours_req.fulfilled_hours == 3
     assert hours_req.is_fulfilled() == False
-
 
     hours_req.attempt_fulfill("ACCT 4301")
     hours_req.attempt_fulfill("FIN 3380")
@@ -135,6 +140,7 @@ def test_hours_requirement() -> None:
     hours_req.attempt_fulfill("FIN 3330")
     assert hours_req.fulfilled_hours == 12
     assert hours_req.is_fulfilled() == True
+
 
 def test_free_elective_requirement() -> None:
     free_elective_req = FreeElectiveRequirement(10, ["HIST 1301", "HIST 1302"])
@@ -165,8 +171,17 @@ def test_free_elective_requirement() -> None:
 
     assert free_elective_req.fulfilled_hours == 0
 
+
 def test_select_requirement() -> None:
-    select_req = SelectRequirement(2, [CourseRequirement("BA 1310"), CourseRequirement("BA 1320"), CourseRequirement("ECON 2301"), CourseRequirement("ECON 2302")])
+    select_req = SelectRequirement(
+        2,
+        [
+            CourseRequirement("BA 1310"),
+            CourseRequirement("BA 1320"),
+            CourseRequirement("ECON 2301"),
+            CourseRequirement("ECON 2302"),
+        ],
+    )
     assert select_req.fulfilled_count == 0
     assert select_req.is_fulfilled() == False
 
@@ -174,14 +189,14 @@ def test_select_requirement() -> None:
     assert select_req.fulfilled_count == 0
     assert select_req.is_fulfilled() == False
 
-    select_req.attempt_fulfill("BA 1320") 
+    select_req.attempt_fulfill("BA 1320")
     assert select_req.fulfilled_count == 1
     assert select_req.is_fulfilled() == False
 
-    select_req.attempt_fulfill("BA 1310") 
+    select_req.attempt_fulfill("BA 1310")
     assert select_req.fulfilled_count == 2
     assert select_req.is_fulfilled() == True
 
-    select_req.attempt_fulfill("ECON 2301") 
+    select_req.attempt_fulfill("ECON 2301")
     assert select_req.fulfilled_count == 2
     assert select_req.is_fulfilled() == True

--- a/major/tests/test_solver.py
+++ b/major/tests/test_solver.py
@@ -135,11 +135,10 @@ def test_accounting_solver() -> None:
         "ACCT 4301",
         "ACCT 4302",
         "ACCT 4336",
-
     ]
 
     GRADUATEABLE_COURSES = [
-           "MATH 1325",
+        "MATH 1325",
         "OPRE 3340",
         "ACCT 2301",
         "ACCT 2302",

--- a/major/tests/test_solver.py
+++ b/major/tests/test_solver.py
@@ -101,3 +101,92 @@ def test_computer_science_solver() -> None:
     print(str(solver))
 
     assert solver.can_graduate()
+
+
+def test_accounting_solver() -> None:
+    MISSING_FREE_ELECTIVES = [
+        "MATH 1325",
+        "OPRE 3340",
+        "ACCT 2301",
+        "ACCT 2302",
+        "BLAW 2301",
+        "CS 2305",
+        "OPRE 3360",
+        "BA 1310",
+        "BA 1320",
+        "BCOM 1300",
+        "BCOM 4300",
+        "IMS 3310",
+        "FIN 3320",
+        "ITSS 3300",
+        "OPRE 3310",
+        "OBHR 3310",
+        "MKT 3300",
+        "ENTP 4395",
+        "ACCT 3312",
+        "ACCT 3331",
+        "ACCT 3332",
+        "ACCT 3341",
+        "ACCT 3350",
+        "ACCT 4334",
+        "ACCT 4342",
+        "BA 4090",
+        "ACCT 3322",
+        "ACCT 4301",
+        "ACCT 4302",
+        "ACCT 4336",
+
+    ]
+
+    GRADUATEABLE_COURSES = [
+           "MATH 1325",
+        "OPRE 3340",
+        "ACCT 2301",
+        "ACCT 2302",
+        "BLAW 2301",
+        "CS 2305",
+        "OPRE 3360",
+        "BA 1310",
+        "BA 1320",
+        "BCOM 1300",
+        "BCOM 4300",
+        "IMS 3310",
+        "FIN 3320",
+        "ITSS 3300",
+        "OPRE 3310",
+        "OBHR 3310",
+        "MKT 3300",
+        "ENTP 4395",
+        "ACCT 3312",
+        "ACCT 3331",
+        "ACCT 3332",
+        "ACCT 3341",
+        "ACCT 3350",
+        "ACCT 4334",
+        "ACCT 4342",
+        "BA 4090",
+        "ACCT 3322",
+        "ACCT 4301",
+        "ACCT 4302",
+        "ACCT 4336",
+        "MKT 4360",
+    ]
+
+    data = json.loads(open("degree_data/accounting.json", "r").read())
+
+    requirements_data = data["requirements"]["major"]
+
+    requirements: list[AbstractRequirement] = []
+
+    for req_data in requirements_data:
+        requirements.append(REQUIREMENTS_MAP[req_data["matcher"]].from_json(req_data))
+
+    solver = MajorRequirementsSolver(MISSING_FREE_ELECTIVES, requirements).solve()
+    print(str(solver))
+
+    assert solver.can_graduate() == False
+
+    solver = MajorRequirementsSolver(GRADUATEABLE_COURSES, requirements).solve()
+    print(str(solver))
+
+    assert solver.can_graduate()


### PR DESCRIPTION
This PR adds the accounting major. It also introduces two new requirement matchers: SelectRequirement and HoursRequirement. SelectRequirement requires x courses from a list of y. HoursRequirement requires a certain number of hours given a list of courses.

Notes
1. We need a way to add descriptions to requirements in the future. This is especially important for the JSOM requirements (community service or internship)
2. No support for 4VXX classes at the moment since it has a variable number of hours. I think the best course of action for this is to use the bypass system, as it will allow us to assign a certain number of hours to the course. We can code a way to do bypass sometime in the future, probably when we connect the solvers to the API.
3. Some courses count for two places in major courses (generally due to free elective involed). Idea for this is to have a mapping of courses that occur multiple times, then duplicate before matching courses to requirements. This is definitely up for discussion though